### PR TITLE
Pass options to juice

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ var es = require('event-stream'),
 module.exports = function(options){
   options = options || {};
   return es.map(function(file, fn){
-      juice(file.contents.toString(), {}, function(err, html){
+      juice(file.contents.toString(), options, function(err, html){
         if(err) return fn(err);
         file.contents = new Buffer(html);
         fn(null, file);


### PR DESCRIPTION
Currently, we're not able to pass options to juice.

You hardcoded empty object as options.